### PR TITLE
Remove unnecessary assign_entity

### DIFF
--- a/datapack/function.py
+++ b/datapack/function.py
@@ -315,7 +315,6 @@ class Function:
             elif expression[0] == '@':  # an entity
 
                 self.refs[dest] = 'e'
-                self.add_command(assign_entity(expression, dest))
 
             elif expression[0] == '#':  # a clarifier
 


### PR DESCRIPTION
This was giving me an error when I tried to do `entity = summon ...`, it would summon the entity with the tag in the `Tags:[]` array, but then in the next line it would put a `tag @ add <tag>`, which was invalid syntax and would break the datapack.